### PR TITLE
test: Silence expected subprocess failure

### DIFF
--- a/test/ruby_memcheck/ruby_memcheck_test.rb
+++ b/test/ruby_memcheck/ruby_memcheck_test.rb
@@ -116,7 +116,7 @@ module RubyMemcheck
     end
 
     def test_ruby_failure
-      ok, _ = run_with_memcheck(<<~RUBY, raise_on_failure: false)
+      ok, _ = run_with_memcheck(<<~RUBY, raise_on_failure: false, spawn_opts: { out: "/dev/null", err: "/dev/null" })
         foobar
       RUBY
 
@@ -127,7 +127,7 @@ module RubyMemcheck
 
     private
 
-    def run_with_memcheck(code, raise_on_failure: true)
+    def run_with_memcheck(code, raise_on_failure: true, spawn_opts: {})
       script = Tempfile.new
       script.write("require 'ruby_memcheck_c_test'\n#{code}")
       script.flush
@@ -137,7 +137,8 @@ module RubyMemcheck
 
       @test_task.ruby(
         "-I#{File.join(__dir__, "ext")}",
-        script.path
+        script.path,
+        **spawn_opts
       ) do |ok_val, status_val|
         ok = ok_val
         status = status_val


### PR DESCRIPTION
## Problem

It looks like there was a problem in a test when this error in the test output

```
/tmp/20211020-55116-p9v8k5:2:in `<main>': undefined local variable or method `foobar' for main:Object (NameError)
```

but it turns out that it was just an expected failure

## Solution

Redirect the output for the subprocess in that test to /dev/null to silence it.