### PR TITLE
Automatically teardown after tests complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,18 +121,6 @@ The easiest way to use this gem is to use it on your test suite (minitest or RSp
       end
       ```
 
-1. Add the following line to your `test_helper.rb` or `spec_helper.rb`:
-
-    ```ruby
-    at_exit { GC.start }
-    ```
-
-    This will run a major garbage collection cycle before the Ruby process shuts down. This will ensure that any remaining Ruby objects are collected which will prevent Valgrind from reporting false positives.
-
-    It is safest to add the line above at the very first line of `test_helper.rb` or `spec_helper.rb`.
-
-    - **For minitest:** It is important that the line above is added BEFORE the `require "minitest/autorun"` line.
-
 1. You're ready to run your test suite with Valgrind using `rake test:valgrind` or `rake spec:valgrind`! Note that this will take a while to run because Valgrind will make Ruby significantly slower.
 1. (Optional) If you find false positives in the output, you can create Valgrind suppression files. See the [`Suppression files`](#suppression-files) section for more details.
 

--- a/lib/ruby_memcheck/rspec/rake_task.rb
+++ b/lib/ruby_memcheck/rspec/rake_task.rb
@@ -40,6 +40,7 @@ module RubyMemcheck
       def spec_command
         # First part of command is Ruby
         args = super.split(" ")[1..]
+        args.unshift("-r" + File.expand_path(File.join(__dir__, "../test_helper.rb")))
 
         configuration.command(args)
       end

--- a/lib/ruby_memcheck/test_helper.rb
+++ b/lib/ruby_memcheck/test_helper.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+at_exit { GC.start }

--- a/lib/ruby_memcheck/test_task.rb
+++ b/lib/ruby_memcheck/test_task.rb
@@ -18,6 +18,7 @@ module RubyMemcheck
     end
 
     def ruby(*args, **options, &block)
+      args.unshift("-r" + File.expand_path(File.join(__dir__, "test_helper.rb")))
       command = configuration.command(args)
       sh(command, **options) do |ok, res|
         report_valgrind_errors

--- a/test/ruby_memcheck/shared_test_task_reporter_tests.rb
+++ b/test/ruby_memcheck/shared_test_task_reporter_tests.rb
@@ -188,6 +188,18 @@ module RubyMemcheck
       assert_match(/^ \*memory_leak \(ruby_memcheck_c_test\.c:\d+\)$/, output)
     end
 
+    def test_test_helper_is_loaded
+      Tempfile.create do |tempfile|
+        ok = run_with_memcheck(<<~RUBY)
+          File.write(#{tempfile.path.inspect}, $LOADED_FEATURES.join("\n"))
+        RUBY
+
+        assert(ok)
+        assert_empty(@test_task.errors)
+        assert_includes(tempfile.read, File.expand_path(File.join(__dir__, "../../lib/ruby_memcheck/test_helper.rb")))
+      end
+    end
+
     private
 
     def run_with_memcheck(code, raise_on_failure: true, spawn_opts: {})


### PR DESCRIPTION
This commit changes the minitest and RSpec rake tasks to automatically load lib/ruby_memcheck/test_helper.rb to automatically perform teardown. This removes the need to do:

    at_exit { GC.start }