### PR TITLE
Add default Rust configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The easiest way to use this gem is to use it on your test suite (minitest or RSp
 
 1. Setup the test task for your test framework.
     - **minitest**
-    
+
       Locate your test task(s) in your Rakefile. You can identify it with a call to `Rake::TestTask.new`.
 
       Create a namespace under the test task and create a `RubyMemcheck::TestTask` with the same configuration.
@@ -183,6 +183,8 @@ Let's celebrate wins from this gem! If this gem was useful for you, please share
   - Found 1 memory leak: [#9150](https://github.com/protocolbuffers/protobuf/pull/9150)
 - [`gRPC`](https://github.com/grpc/grpc):
   - Found 1 memory leak: [#27900](https://github.com/grpc/grpc/pull/27900)
+- [`wasmtime-rb`](https://github.com/bytecodealliance/wasmtime-rb)
+  - Found 1 memory leak: [#26](https://github.com/bytecodealliance/wasmtime-rb/pull/26)
 
 ## License
 

--- a/lib/ruby_memcheck/configuration.rb
+++ b/lib/ruby_memcheck/configuration.rb
@@ -111,7 +111,7 @@ module RubyMemcheck
       (0..3).reverse_each { |i| versions << full_ruby_version.split(".")[0, i].join(".") }
       versions << RUBY_ENGINE
 
-      versions.map do |version|
+      files = versions.map do |version|
         old_format_files = Dir[File.join(dir, "#{binary_name}_#{version}.supp")]
 
         unless old_format_files.empty?
@@ -121,6 +121,8 @@ module RubyMemcheck
 
         old_format_files + Dir[File.join(dir, "#{version}.supp")]
       end.flatten
+
+      files + Dir[File.join(dir, "rust.supp")]
     end
   end
 end

--- a/lib/ruby_memcheck/configuration.rb
+++ b/lib/ruby_memcheck/configuration.rb
@@ -111,7 +111,7 @@ module RubyMemcheck
       (0..3).reverse_each { |i| versions << full_ruby_version.split(".")[0, i].join(".") }
       versions << RUBY_ENGINE
 
-      files = versions.map do |version|
+      versions.map do |version|
         old_format_files = Dir[File.join(dir, "#{binary_name}_#{version}.supp")]
 
         unless old_format_files.empty?
@@ -121,8 +121,6 @@ module RubyMemcheck
 
         old_format_files + Dir[File.join(dir, "#{version}.supp")]
       end.flatten
-
-      files + Dir[File.join(dir, "rust.supp")]
     end
   end
 end

--- a/suppressions/ruby.supp
+++ b/suppressions/ruby.supp
@@ -34,3 +34,19 @@
   fun:each_location*
   ...
 }
+{
+  Rust probes for statx(buf)
+  Memcheck:Param
+  statx(buf)
+  ...
+  fun:*try_statx*
+  ...
+}
+{
+  Rust probes for statx(file_name)
+  Memcheck:Param
+  statx(file_name)
+  ...
+  fun:*try_statx*
+  ...
+}

--- a/suppressions/ruby.supp
+++ b/suppressions/ruby.supp
@@ -35,7 +35,7 @@
   ...
 }
 {
-  Rust probes for statx(buf)
+  Rust probes for statx(buf), will be fixed in Valgrind >= 3.1.6.0
   Memcheck:Param
   statx(buf)
   ...
@@ -43,7 +43,7 @@
   ...
 }
 {
-  Rust probes for statx(file_name)
+  Rust probes for statx(file_name), will be fixed in Valgrind >= 3.1.6.0
   Memcheck:Param
   statx(file_name)
   ...


### PR DESCRIPTION
`ruby_memcheck` has been incredibly useful for various Rust extensions I've worked on, and I'd love to see more adoption of it for Rust gems as well. This PR sets 2 suppressions that are safely ignorable on the Rust side.

Valgrind doesn't seem to like how Rust probes for `statx` (see https://github.com/rust-lang/rust/issues/68979 and https://bugzilla.mozilla.org/show_bug.cgi?id=1606007). The issue has been fixed upstream in Valgrind, but many distros are stuck on an older version. Since the issue is inactionable by the user, suppressing it by default will make `ruby_memcheck` easier to integrate for Rust gems.