### PR TITLE
feat: use Nokogiri's HUGE parse option

### DIFF
--- a/lib/ruby_memcheck/test_task_reporter.rb
+++ b/lib/ruby_memcheck/test_task_reporter.rb
@@ -31,7 +31,10 @@ module RubyMemcheck
       @errors = []
 
       xml_files.each do |file|
-        Nokogiri::XML::Reader(File.open(file)).each do |node|
+        reader = Nokogiri::XML::Reader(File.open(file)) do |config| # rubocop:disable Style/SymbolProc
+          config.huge
+        end
+        reader.each do |node|
           next unless node.name == "error" && node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
 
           error_xml = Nokogiri::XML::Document.parse(node.outer_xml).root


### PR DESCRIPTION
In https://github.com/sparklemotion/nokogiri/issues/2865, which upgrades the latest libxml2 release, I [started seeing failures](https://github.com/sparklemotion/nokogiri/actions/runs/4831357226/jobs/8614155369#step:7:4476) that seem related to the larges sizes of the valgrind output files generated by Nokogiri's test suite:

```
Nokogiri::XML::SyntaxError: 360080:11: FATAL: internal error: Huge input lookup
/__w/nokogiri/nokogiri/lib/nokogiri/xml/reader.rb:99:in `read'
/__w/nokogiri/nokogiri/lib/nokogiri/xml/reader.rb:99:in `each'
/usr/local/bundle/gems/ruby_memcheck-1.3.1/lib/ruby_memcheck/test_task_reporter.rb:34:in `block in parse_valgrind_output'
/usr/local/bundle/gems/ruby_memcheck-1.3.1/lib/ruby_memcheck/test_task_reporter.rb:33:in `each'
/usr/local/bundle/gems/ruby_memcheck-1.3.1/lib/ruby_memcheck/test_task_reporter.rb:33:in `parse_valgrind_output'
```

I haven't dug in too much as to why libxml2 2.11.0 is complaining about this, but a lot of the buffering code got rewritten. See the [release notes](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.11.0) for more information, but the work is being described as:

> Refactoring has begun on some buffering and encoding code with the goal of simplifying this part of the code base and improving error reporting.

In any case, setting the `HUGE` parse option will avoid these errors, at the cost of a slight performance tradeoff.
