### PR TITLE
Automatically detect Ruby native extensions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ jobs:
       fail-fast: false
       matrix:
         entry:
-          - { ruby: '2.7', allowed-failure: false }
           - { ruby: '3.0', allowed-failure: false }
           - { ruby: '3.1', allowed-failure: false }
           - { ruby: '3.2', allowed-failure: false }

--- a/README.md
+++ b/README.md
@@ -84,12 +84,6 @@ The easiest way to use this gem is to use it on your test suite (minitest or RSp
       require "ruby_memcheck/rspec/rake_task"
       ```
 
-1. Configure the gem by calling `RubyMemcheck.config`. You must pass it your binary name. This is the same value you passed into `create_makefile` in your `extconf.rb` file. Make sure this value is correct or it will filter out almost everything as a false-positive!
-
-    ```ruby
-    RubyMemcheck.config(binary_name: "your_binary_name")
-    ```
-
 1. Setup the test task for your test framework.
     - **minitest**
 
@@ -145,11 +139,10 @@ The easiest way to use this gem is to use it on your test suite (minitest or RSp
 
 ## Configuration
 
-When you run `RubyMemcheck.config`, you are creating a default `RubyMemcheck::Configuration`. By default, the Rake tasks for minitest and RSpec will use this configuration. You can also manually pass in a `Configuration` object as the first argument to the constructor of `RubyMemcheck::TestTask` or `RubyMemcheck::RSpec::RakeTask` to use a different `Configuration` object rather than the default one.
+If you want to override any of the default configurations you can call `RubyMemcheck.config` after `require "ruby_memcheck"`. This will create a default `RubyMemcheck::Configuration`. By default, the Rake tasks for minitest and RSpec will use this configuration. You can also manually pass in a `Configuration` object as the first argument to the constructor of `RubyMemcheck::TestTask` or `RubyMemcheck::RSpec::RakeTask` to use a different `Configuration` object rather than the default one.
 
 `RubyMemcheck::Configuration` accepts a variety of keyword arguments. Here are all the arguments:
 
-- `binary_name`: Required. The binary name of your native extension gem. This is the same value you passed into `create_makefile` in your `extconf.rb` file.
 - `ruby`: Optional. The command to run to invoke Ruby. Defaults to the Ruby that is currently being used.
 - `valgrind`: Optional. The command to run to invoke Valgrind. Defaults to the string `"valgrind"`.
 - `valgrind_options`: Optional. Array of options to pass into Valgrind. This is only present as an escape hatch, so avoid using it. This may be deprecated or removed in future versions.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ When you run `RubyMemcheck.config`, you are creating a default `RubyMemcheck::Co
 - `valgrind_suppressions_dir`: Optional. The string path of the directory that stores suppression files for Valgrind. See the [`Suppression files`](#suppression-files) section for more details. Defaults to `suppressions`.
 - `valgrind_generate_suppressions`: Optional. Whether suppressions should also be outputted along with the errors. the [`Suppression files`](#suppression-files) section for more details. Defaults to `false`.
 - `skipped_ruby_functions`: Optional. Ruby functions that are ignored because they are considered a call back into Ruby. This is only present as an escape hatch, so avoid using it. If you find another Ruby function that is a false positive because it calls back into Ruby, please send a patch into this repo. Otherwise, use a Valgrind suppression file.
-- `valgrind_xml_dir`: Optional. The directory to store temporary XML files for Valgrind. It defaults to a temporary directory. This is present for development debugging, so you shouldn't have to use it.
+- `temp_dir`: Optional. The directory to store temporary files. It defaults to a temporary directory. This is present for development debugging, so you shouldn't have to use it.
 - `output_io`: Optional. The `IO` object to output Valgrind errors to. Defaults to standard error.
 - `filter_all_errors`: Optional. Whether to filter all kinds of Valgrind errors (not just memory leaks). This feature should only be used if you're encountering a large number of illegal memory accesses coming from Ruby. If you need to use this feature, you may have found a bug inside of Ruby. Consider reporting it to the [Ruby bug tracker](https://bugs.ruby-lang.org/projects/ruby-master/issues/new). Defaults to `false`.
 

--- a/Rakefile
+++ b/Rakefile
@@ -11,9 +11,16 @@ Rake::TestTask.new(test: "test:compile") do |t|
 end
 
 namespace :test do
-  Rake::ExtensionTask.new("ruby_memcheck_c_test") do |ext|
+  Rake::ExtensionTask.new("ruby_memcheck_c_test_one") do |ext|
     ext.ext_dir = "test/ruby_memcheck/ext"
     ext.lib_dir = "test/ruby_memcheck/ext"
+    ext.config_script = "extconf_one.rb"
+  end
+
+  Rake::ExtensionTask.new("ruby_memcheck_c_test_two") do |ext|
+    ext.ext_dir = "test/ruby_memcheck/ext"
+    ext.lib_dir = "test/ruby_memcheck/ext"
+    ext.config_script = "extconf_two.rb"
   end
 end
 

--- a/lib/ruby_memcheck.rb
+++ b/lib/ruby_memcheck.rb
@@ -19,11 +19,7 @@ module RubyMemcheck
     end
 
     def default_configuration
-      unless @default_configuration
-        raise "RubyMemcheck is not configured with a default configuration. "\
-          "Please run RubyMemcheck.config before using it."
-      end
-      @default_configuration
+      @default_configuration ||= config
     end
   end
 end

--- a/lib/ruby_memcheck/rspec/rake_task.rb
+++ b/lib/ruby_memcheck/rspec/rake_task.rb
@@ -5,9 +5,8 @@ require "rspec/core/rake_task"
 module RubyMemcheck
   module RSpec
     class RakeTask < ::RSpec::Core::RakeTask
-      include TestTaskReporter
-
       attr_reader :configuration
+      attr_reader :reporter
 
       def initialize(*args)
         @configuration =
@@ -23,14 +22,13 @@ module RubyMemcheck
       def run_task(verbose)
         error = nil
 
-        begin
+        @reporter = TestTaskReporter.new(configuration)
+        @reporter.run_ruby_with_valgrind do
           # RSpec::Core::RakeTask#run_task calls Kernel.exit on failure
           super
         rescue SystemExit => e
           error = e
         end
-
-        report_valgrind_errors
 
         raise error if error
       end

--- a/lib/ruby_memcheck/stack.rb
+++ b/lib/ruby_memcheck/stack.rb
@@ -4,30 +4,28 @@ module RubyMemcheck
   class Stack
     attr_reader :configuration, :frames
 
-    def initialize(configuration, stack_xml)
+    def initialize(configuration, loaded_binaries, stack_xml)
       @configuration = configuration
-      @frames = stack_xml.xpath("frame").map { |frame| Frame.new(configuration, frame) }
+      @frames = stack_xml.xpath("frame").map { |frame| Frame.new(configuration, loaded_binaries, frame) }
     end
 
     def skip?
       in_binary = false
 
       frames.each do |frame|
-        fn = frame.fn
-
         if frame.in_ruby?
           # If a stack from from the binary was encountered first, then this
           # memory leak did not occur from Ruby
           unless in_binary
             # Skip this stack because it was called from Ruby
-            return true if configuration.skipped_ruby_functions.any? { |r| r.match?(fn) }
+            return true if configuration.skipped_ruby_functions.any? { |r| r.match?(frame.fn) }
           end
         elsif frame.in_binary?
           in_binary = true
 
           # Skip the Init function because it is only ever called once, so
           # leaks in it cannot cause memory bloat
-          return true if fn == "Init_#{configuration.binary_name}"
+          return true if frame.binary_init_func?
         end
       end
 

--- a/lib/ruby_memcheck/test_helper.rb
+++ b/lib/ruby_memcheck/test_helper.rb
@@ -1,3 +1,9 @@
 # frozen_string_literal: true
 
-at_exit { GC.start }
+at_exit do
+  File.open(ENV["RUBY_MEMCHECK_LOADED_FEATURES_FILE"], "w") do |f|
+    f.write($LOADED_FEATURES.join("\n"))
+  end
+
+  GC.start
+end

--- a/lib/ruby_memcheck/test_task.rb
+++ b/lib/ruby_memcheck/test_task.rb
@@ -2,9 +2,8 @@
 
 module RubyMemcheck
   class TestTask < Rake::TestTask
-    include TestTaskReporter
-
     attr_reader :configuration
+    attr_reader :reporter
 
     def initialize(*args)
       @configuration =
@@ -19,8 +18,13 @@ module RubyMemcheck
 
     def ruby(*args, **options, &block)
       command = configuration.command(args)
+
+      @reporter = TestTaskReporter.new(configuration)
+
+      @reporter.setup
+
       sh(command, **options) do |ok, res|
-        report_valgrind_errors
+        @reporter.report_valgrind_errors
 
         yield ok, res if block_given?
       end

--- a/lib/ruby_memcheck/test_task_reporter.rb
+++ b/lib/ruby_memcheck/test_task_reporter.rb
@@ -20,6 +20,7 @@ module RubyMemcheck
 
     def setup
       ENV["RUBY_MEMCHECK_LOADED_FEATURES_FILE"] = File.expand_path(configuration.loaded_features_file)
+      ENV["RUBY_MEMCHECK_RUNNING"] = "1"
     end
 
     def report_valgrind_errors

--- a/lib/ruby_memcheck/valgrind_error.rb
+++ b/lib/ruby_memcheck/valgrind_error.rb
@@ -7,7 +7,7 @@ module RubyMemcheck
 
     attr_reader :kind, :msg, :stack, :suppression
 
-    def initialize(configuration, error)
+    def initialize(configuration, loaded_binaries, error)
       @kind = error.at_xpath("kind").content
       @msg =
         if kind_leak?
@@ -15,7 +15,7 @@ module RubyMemcheck
         else
           error.at_xpath("what").content
         end
-      @stack = Stack.new(configuration, error.at_xpath("stack"))
+      @stack = Stack.new(configuration, loaded_binaries, error.at_xpath("stack"))
       @configuration = configuration
 
       suppression_node = error.at_xpath("suppression")

--- a/suppressions/ruby.supp
+++ b/suppressions/ruby.supp
@@ -50,3 +50,11 @@
   fun:*try_statx*
   ...
 }
+{
+  strscan_do_scan in strscan.c will sometimes replace the ptr of the regex, which can be reported as a memory leak if the regex is stored in an iseq. https://github.com/ruby/ruby/pull/8136
+  Memcheck:Leak
+  ...
+  fun:rb_reg_prepare_re
+  fun:strscan_do_scan
+  ...
+}

--- a/test/ruby_memcheck/ext/extconf.rb
+++ b/test/ruby_memcheck/ext/extconf.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require "mkmf"
-
-$warnflags&.gsub!(/-Wdeclaration-after-statement/, "")
-
-create_makefile("ruby_memcheck_c_test")

--- a/test/ruby_memcheck/ext/extconf_one.rb
+++ b/test/ruby_memcheck/ext/extconf_one.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "mkmf"
+
+$warnflags&.gsub!(/-Wdeclaration-after-statement/, "") # rubocop:disable Style/GlobalVars
+
+create_makefile("ruby_memcheck_c_test_one")

--- a/test/ruby_memcheck/ext/extconf_two.rb
+++ b/test/ruby_memcheck/ext/extconf_two.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "mkmf"
+
+$warnflags&.gsub!(/-Wdeclaration-after-statement/, "") # rubocop:disable Style/GlobalVars
+
+create_makefile("ruby_memcheck_c_test_two")

--- a/test/ruby_memcheck/ext/ruby_memcheck_c_test_one.c
+++ b/test/ruby_memcheck/ext/ruby_memcheck_c_test_one.c
@@ -1,6 +1,6 @@
 #include <ruby.h>
 
-VALUE cRubyMemcheckCTest;
+static VALUE cRubyMemcheckCTestOne;
 
 static VALUE no_memory_leak(VALUE _)
 {
@@ -46,18 +46,18 @@ static VALUE call_into_ruby_mem_leak(VALUE obj)
     return Qnil;
 }
 
-void Init_ruby_memcheck_c_test(void)
+void Init_ruby_memcheck_c_test_one(void)
 {
     /* Memory leaks in the Init functions should be ignored. */
     allocate_memory_leak();
 
     VALUE mRubyMemcheck = rb_define_module("RubyMemcheck");
-    cRubyMemcheckCTest = rb_define_class_under(mRubyMemcheck, "CTest", rb_cObject);
-    rb_global_variable(&cRubyMemcheckCTest);
+    cRubyMemcheckCTestOne = rb_define_class_under(mRubyMemcheck, "CTestOne", rb_cObject);
+    rb_global_variable(&cRubyMemcheckCTestOne);
 
-    rb_define_method(cRubyMemcheckCTest, "no_memory_leak", no_memory_leak,  0);
-    rb_define_method(cRubyMemcheckCTest, "memory_leak", memory_leak, 0);
-    rb_define_method(cRubyMemcheckCTest, "use_after_free", use_after_free, 0);
-    rb_define_method(cRubyMemcheckCTest, "uninitialized_value", uninitialized_value, 0);
-    rb_define_method(cRubyMemcheckCTest, "call_into_ruby_mem_leak", call_into_ruby_mem_leak, 0);
+    rb_define_method(cRubyMemcheckCTestOne, "no_memory_leak", no_memory_leak, 0);
+    rb_define_method(cRubyMemcheckCTestOne, "memory_leak", memory_leak, 0);
+    rb_define_method(cRubyMemcheckCTestOne, "use_after_free", use_after_free, 0);
+    rb_define_method(cRubyMemcheckCTestOne, "uninitialized_value", uninitialized_value, 0);
+    rb_define_method(cRubyMemcheckCTestOne, "call_into_ruby_mem_leak", call_into_ruby_mem_leak, 0);
 }

--- a/test/ruby_memcheck/ext/ruby_memcheck_c_test_one.c
+++ b/test/ruby_memcheck/ext/ruby_memcheck_c_test_one.c
@@ -2,25 +2,25 @@
 
 static VALUE cRubyMemcheckCTestOne;
 
-static VALUE no_memory_leak(VALUE _)
+static VALUE c_test_one_no_memory_leak(VALUE _)
 {
     return Qnil;
 }
 
 /* This function must not be inlined to ensure that it has a stack frame. */
-static void __attribute__((noinline)) allocate_memory_leak(void)
+static void __attribute__((noinline)) c_test_one_allocate_memory_leak(void)
 {
     volatile char *ptr = malloc(100);
     ptr[0] = 'a';
-} 
+}
 
-static VALUE memory_leak(VALUE _)
+static VALUE c_test_one_memory_leak(VALUE _)
 {
-    allocate_memory_leak();
+    c_test_one_allocate_memory_leak();
     return Qnil;
 }
 
-static VALUE use_after_free(VALUE _)
+static VALUE c_test_one_use_after_free(VALUE _)
 {
     volatile char *ptr = malloc(100);
     free((void *)ptr);
@@ -28,7 +28,7 @@ static VALUE use_after_free(VALUE _)
     return Qnil;
 }
 
-static VALUE uninitialized_value(VALUE _)
+static VALUE c_test_one_uninitialized_value(VALUE _)
 {
     volatile int foo;
 #pragma GCC diagnostic ignored "-Wuninitialized"
@@ -36,7 +36,7 @@ static VALUE uninitialized_value(VALUE _)
 #pragma GCC diagnostic pop
 }
 
-static VALUE call_into_ruby_mem_leak(VALUE obj)
+static VALUE c_test_one_call_into_ruby_mem_leak(VALUE obj)
 {
     char str[20];
     for (int i = 0; i < 10000; i++) {
@@ -49,15 +49,15 @@ static VALUE call_into_ruby_mem_leak(VALUE obj)
 void Init_ruby_memcheck_c_test_one(void)
 {
     /* Memory leaks in the Init functions should be ignored. */
-    allocate_memory_leak();
+    c_test_one_allocate_memory_leak();
 
     VALUE mRubyMemcheck = rb_define_module("RubyMemcheck");
     cRubyMemcheckCTestOne = rb_define_class_under(mRubyMemcheck, "CTestOne", rb_cObject);
     rb_global_variable(&cRubyMemcheckCTestOne);
 
-    rb_define_method(cRubyMemcheckCTestOne, "no_memory_leak", no_memory_leak, 0);
-    rb_define_method(cRubyMemcheckCTestOne, "memory_leak", memory_leak, 0);
-    rb_define_method(cRubyMemcheckCTestOne, "use_after_free", use_after_free, 0);
-    rb_define_method(cRubyMemcheckCTestOne, "uninitialized_value", uninitialized_value, 0);
-    rb_define_method(cRubyMemcheckCTestOne, "call_into_ruby_mem_leak", call_into_ruby_mem_leak, 0);
+    rb_define_method(cRubyMemcheckCTestOne, "no_memory_leak", c_test_one_no_memory_leak, 0);
+    rb_define_method(cRubyMemcheckCTestOne, "memory_leak", c_test_one_memory_leak, 0);
+    rb_define_method(cRubyMemcheckCTestOne, "use_after_free", c_test_one_use_after_free, 0);
+    rb_define_method(cRubyMemcheckCTestOne, "uninitialized_value", c_test_one_uninitialized_value, 0);
+    rb_define_method(cRubyMemcheckCTestOne, "call_into_ruby_mem_leak", c_test_one_call_into_ruby_mem_leak, 0);
 }

--- a/test/ruby_memcheck/ext/ruby_memcheck_c_test_two.c
+++ b/test/ruby_memcheck/ext/ruby_memcheck_c_test_two.c
@@ -1,0 +1,63 @@
+#include <ruby.h>
+
+static VALUE cRubyMemcheckCTestTwo;
+
+static VALUE no_memory_leak(VALUE _)
+{
+    return Qnil;
+}
+
+/* This function must not be inlined to ensure that it has a stack frame. */
+static void __attribute__((noinline)) allocate_memory_leak(void)
+{
+    volatile char *ptr = malloc(100);
+    ptr[0] = 'a';
+} 
+
+static VALUE memory_leak(VALUE _)
+{
+    allocate_memory_leak();
+    return Qnil;
+}
+
+static VALUE use_after_free(VALUE _)
+{
+    volatile char *ptr = malloc(100);
+    free((void *)ptr);
+    ptr[0] = 'a';
+    return Qnil;
+}
+
+static VALUE uninitialized_value(VALUE _)
+{
+    volatile int foo;
+#pragma GCC diagnostic ignored "-Wuninitialized"
+    return foo == 0 ? rb_str_new_cstr("zero") : rb_str_new_cstr("not zero");
+#pragma GCC diagnostic pop
+}
+
+static VALUE call_into_ruby_mem_leak(VALUE obj)
+{
+    char str[20];
+    for (int i = 0; i < 10000; i++) {
+        sprintf(str, "foobar%d", i);
+        rb_intern(str);
+    }
+    return Qnil;
+}
+
+void Init_ruby_memcheck_c_test_two(void)
+{
+    /* Memory leaks in the Init functions should be ignored. */
+    allocate_memory_leak();
+
+    VALUE mRubyMemcheck = rb_define_module("RubyMemcheck");
+    cRubyMemcheckCTestTwo = rb_define_class_under(mRubyMemcheck, "CTestTwo", rb_cObject);
+    rb_global_variable(&cRubyMemcheckCTestTwo);
+
+    rb_define_method(cRubyMemcheckCTestTwo, "no_memory_leak", no_memory_leak, 0);
+    rb_define_method(cRubyMemcheckCTestTwo, "memory_leak", memory_leak, 0);
+    rb_define_method(cRubyMemcheckCTestTwo, "use_after_free", use_after_free, 0);
+    rb_define_method(cRubyMemcheckCTestTwo, "uninitialized_value", uninitialized_value, 0);
+    rb_define_method(cRubyMemcheckCTestTwo, "call_into_ruby_mem_leak", call_into_ruby_mem_leak, 0);
+}

--- a/test/ruby_memcheck/ext/ruby_memcheck_c_test_two.c
+++ b/test/ruby_memcheck/ext/ruby_memcheck_c_test_two.c
@@ -2,25 +2,25 @@
 
 static VALUE cRubyMemcheckCTestTwo;
 
-static VALUE no_memory_leak(VALUE _)
+static VALUE c_test_two_no_memory_leak(VALUE _)
 {
     return Qnil;
 }
 
 /* This function must not be inlined to ensure that it has a stack frame. */
-static void __attribute__((noinline)) allocate_memory_leak(void)
+static void __attribute__((noinline)) c_test_two_allocate_memory_leak(void)
 {
     volatile char *ptr = malloc(100);
     ptr[0] = 'a';
-} 
+}
 
-static VALUE memory_leak(VALUE _)
+static VALUE c_test_two_memory_leak(VALUE _)
 {
-    allocate_memory_leak();
+    c_test_two_allocate_memory_leak();
     return Qnil;
 }
 
-static VALUE use_after_free(VALUE _)
+static VALUE c_test_two_use_after_free(VALUE _)
 {
     volatile char *ptr = malloc(100);
     free((void *)ptr);
@@ -28,7 +28,7 @@ static VALUE use_after_free(VALUE _)
     return Qnil;
 }
 
-static VALUE uninitialized_value(VALUE _)
+static VALUE c_test_two_uninitialized_value(VALUE _)
 {
     volatile int foo;
 #pragma GCC diagnostic ignored "-Wuninitialized"
@@ -36,7 +36,7 @@ static VALUE uninitialized_value(VALUE _)
 #pragma GCC diagnostic pop
 }
 
-static VALUE call_into_ruby_mem_leak(VALUE obj)
+static VALUE c_test_two_call_into_ruby_mem_leak(VALUE obj)
 {
     char str[20];
     for (int i = 0; i < 10000; i++) {
@@ -49,15 +49,15 @@ static VALUE call_into_ruby_mem_leak(VALUE obj)
 void Init_ruby_memcheck_c_test_two(void)
 {
     /* Memory leaks in the Init functions should be ignored. */
-    allocate_memory_leak();
+    c_test_two_allocate_memory_leak();
 
     VALUE mRubyMemcheck = rb_define_module("RubyMemcheck");
     cRubyMemcheckCTestTwo = rb_define_class_under(mRubyMemcheck, "CTestTwo", rb_cObject);
     rb_global_variable(&cRubyMemcheckCTestTwo);
 
-    rb_define_method(cRubyMemcheckCTestTwo, "no_memory_leak", no_memory_leak, 0);
-    rb_define_method(cRubyMemcheckCTestTwo, "memory_leak", memory_leak, 0);
-    rb_define_method(cRubyMemcheckCTestTwo, "use_after_free", use_after_free, 0);
-    rb_define_method(cRubyMemcheckCTestTwo, "uninitialized_value", uninitialized_value, 0);
-    rb_define_method(cRubyMemcheckCTestTwo, "call_into_ruby_mem_leak", call_into_ruby_mem_leak, 0);
+    rb_define_method(cRubyMemcheckCTestTwo, "no_memory_leak", c_test_two_no_memory_leak, 0);
+    rb_define_method(cRubyMemcheckCTestTwo, "memory_leak", c_test_two_memory_leak, 0);
+    rb_define_method(cRubyMemcheckCTestTwo, "use_after_free", c_test_two_use_after_free, 0);
+    rb_define_method(cRubyMemcheckCTestTwo, "uninitialized_value", c_test_two_uninitialized_value, 0);
+    rb_define_method(cRubyMemcheckCTestTwo, "call_into_ruby_mem_leak", c_test_two_call_into_ruby_mem_leak, 0);
 }

--- a/test/ruby_memcheck/rspec/rake_task_test.rb
+++ b/test/ruby_memcheck/rspec/rake_task_test.rb
@@ -32,9 +32,10 @@ module RubyMemcheck
             $stdout.reopen(File.open("#{stdout_log.path}", "w"))
 
             $LOAD_PATH.unshift("#{File.join(__dir__, "../ext")}")
-            require "ruby_memcheck_c_test"
+            require "ruby_memcheck_c_test_one"
+            require "ruby_memcheck_c_test_two"
 
-            RSpec.describe RubyMemcheck::CTest do
+            RSpec.describe RubyMemcheck do
               it "test" do
                 #{code}
               end

--- a/test/ruby_memcheck/ruby_memcheck_suppression_test.rb
+++ b/test/ruby_memcheck/ruby_memcheck_suppression_test.rb
@@ -6,7 +6,7 @@ require "nokogiri"
 module RubyMemcheck
   class RubyMemcheckSuppressionTest < Minitest::Test
     def setup
-      @configuration = Configuration.new(binary_name: "ruby_memcheck_c_test")
+      @configuration = Configuration.new
     end
 
     def test_given_a_suppression_node

--- a/test/ruby_memcheck/shared_test_task_reporter_tests.rb
+++ b/test/ruby_memcheck/shared_test_task_reporter_tests.rb
@@ -142,9 +142,10 @@ module RubyMemcheck
       end
       assert_equal(RubyMemcheck::TestTaskReporter::VALGRIND_REPORT_MSG, error.message)
 
-      assert_equal(2, @test_task.reporter.errors.length)
-
       output = @output_io.string
+
+      assert_equal(2, @test_task.reporter.errors.length, output)
+
       refute_empty(output)
       assert_match(/^100 bytes in 1 blocks are definitely lost in loss record/, output)
       assert_match(/^ \*memory_leak \(ruby_memcheck_c_test_one\.c:\d+\)$/, output)
@@ -161,9 +162,10 @@ module RubyMemcheck
       end
       assert_equal(RubyMemcheck::TestTaskReporter::VALGRIND_REPORT_MSG, error.message)
 
-      assert_equal(2, @test_task.reporter.errors.length)
-
       output = @output_io.string
+
+      assert_equal(2, @test_task.reporter.errors.length, output)
+
       refute_empty(output)
       assert_match(/^100 bytes in 1 blocks are definitely lost in loss record/, output)
       assert_match(/^ \*memory_leak \(ruby_memcheck_c_test_one\.c:\d+\)$/, output)

--- a/test/ruby_memcheck/shared_test_task_reporter_tests.rb
+++ b/test/ruby_memcheck/shared_test_task_reporter_tests.rb
@@ -27,7 +27,7 @@ module RubyMemcheck
       output = @output_io.string
       refute_empty(output)
       assert_match(/^100 bytes in 1 blocks are definitely lost in loss record/, output)
-      assert_match(/^ \*memory_leak \(ruby_memcheck_c_test_one\.c:\d+\)$/, output)
+      assert_match(/^ \*c_test_one_memory_leak \(ruby_memcheck_c_test_one\.c:\d+\)$/, output)
     end
 
     def test_reports_use_after_free
@@ -43,7 +43,7 @@ module RubyMemcheck
       output = @output_io.string
       refute_empty(output)
       assert_match(/^Invalid write of size 1$/, output)
-      assert_match(/^ \*use_after_free \(ruby_memcheck_c_test_one\.c:\d+\)$/, output)
+      assert_match(/^ \*c_test_one_use_after_free \(ruby_memcheck_c_test_one\.c:\d+\)$/, output)
     end
 
     # Potential improvement: support uninitialized values
@@ -107,10 +107,10 @@ module RubyMemcheck
       output = @output_io.string
       refute_empty(output)
       assert_match(/^100 bytes in 1 blocks are definitely lost in loss record/, output)
-      assert_match(/^ \*memory_leak \(ruby_memcheck_c_test_one\.c:\d+\)$/, output)
+      assert_match(/^ \*c_test_one_memory_leak \(ruby_memcheck_c_test_one\.c:\d+\)$/, output)
       assert_match(/^  insert_a_suppression_name_here/, output)
       assert_match(/^  Memcheck:Leak/, output)
-      assert_match(/^  fun:allocate_memory_leak/, output)
+      assert_match(/^  fun:c_test_one_allocate_memory_leak/, output)
     end
 
     def test_follows_forked_children
@@ -130,7 +130,7 @@ module RubyMemcheck
       output = @output_io.string
       refute_empty(output)
       assert_match(/^100 bytes in 1 blocks are definitely lost in loss record/, output)
-      assert_match(/^ \*memory_leak \(ruby_memcheck_c_test_one\.c:\d+\)$/, output)
+      assert_match(/^ \*c_test_one_memory_leak \(ruby_memcheck_c_test_one\.c:\d+\)$/, output)
     end
 
     def test_reports_multiple_errors
@@ -148,9 +148,9 @@ module RubyMemcheck
 
       refute_empty(output)
       assert_match(/^100 bytes in 1 blocks are definitely lost in loss record/, output)
-      assert_match(/^ \*memory_leak \(ruby_memcheck_c_test_one\.c:\d+\)$/, output)
+      assert_match(/^ \*c_test_one_memory_leak \(ruby_memcheck_c_test_one\.c:\d+\)$/, output)
       assert_match(/^Invalid write of size 1$/, output)
-      assert_match(/^ \*use_after_free \(ruby_memcheck_c_test_one\.c:\d+\)$/, output)
+      assert_match(/^ \*c_test_one_use_after_free \(ruby_memcheck_c_test_one\.c:\d+\)$/, output)
     end
 
     def test_reports_errors_in_all_binaries
@@ -168,8 +168,8 @@ module RubyMemcheck
 
       refute_empty(output)
       assert_match(/^100 bytes in 1 blocks are definitely lost in loss record/, output)
-      assert_match(/^ \*memory_leak \(ruby_memcheck_c_test_one\.c:\d+\)$/, output)
-      assert_match(/^ \*memory_leak \(ruby_memcheck_c_test_two\.c:\d+\)$/, output)
+      assert_match(/^ \*c_test_one_memory_leak \(ruby_memcheck_c_test_one\.c:\d+\)$/, output)
+      assert_match(/^ \*c_test_two_memory_leak \(ruby_memcheck_c_test_two\.c:\d+\)$/, output)
     end
 
     def test_can_run_multiple_times
@@ -208,7 +208,7 @@ module RubyMemcheck
       output = @output_io.string
       refute_empty(output)
       assert_match(/^100 bytes in 1 blocks are definitely lost in loss record/, output)
-      assert_match(/^ \*memory_leak \(ruby_memcheck_c_test_one\.c:\d+\)$/, output)
+      assert_match(/^ \*c_test_one_memory_leak \(ruby_memcheck_c_test_one\.c:\d+\)$/, output)
     end
 
     def test_test_helper_is_loaded

--- a/test/ruby_memcheck/shared_test_task_reporter_tests.rb
+++ b/test/ruby_memcheck/shared_test_task_reporter_tests.rb
@@ -223,6 +223,18 @@ module RubyMemcheck
       end
     end
 
+    def test_envionment_variable_RUBY_MEMCHECK_RUNNING
+      Tempfile.create do |tempfile|
+        ok = run_with_memcheck(<<~RUBY, raise_on_failure: false)
+          File.write(#{tempfile.path.inspect}, ENV["RUBY_MEMCHECK_RUNNING"])
+        RUBY
+
+        assert(ok)
+        assert_empty(@test_task.reporter.errors)
+        assert_includes(tempfile.read, "1")
+      end
+    end
+
     private
 
     def run_with_memcheck(code, raise_on_failure: true, spawn_opts: {})

--- a/test/ruby_memcheck/suppressions/ruby.supp
+++ b/test/ruby_memcheck/suppressions/ruby.supp
@@ -2,6 +2,6 @@
    suppress memory_leak
    Memcheck:Leak
    ...
-   fun:memory_leak
+   fun:c_test_one_memory_leak
    ...
 }

--- a/test/ruby_memcheck/test_task_test.rb
+++ b/test/ruby_memcheck/test_task_test.rb
@@ -18,7 +18,8 @@ module RubyMemcheck
     def run_with_memcheck(code, raise_on_failure: true, spawn_opts: {})
       script = Tempfile.new
       script.write(<<~RUBY)
-        require "ruby_memcheck_c_test"
+        require "ruby_memcheck_c_test_one"
+        require "ruby_memcheck_c_test_two"
         #{code}
       RUBY
       script.flush

--- a/test/ruby_memcheck/valgrind_error_test.rb
+++ b/test/ruby_memcheck/valgrind_error_test.rb
@@ -6,7 +6,7 @@ require "nokogiri"
 module RubyMemcheck
   class ValgrindErrorTest < Minitest::Test
     def setup
-      @configuration = Configuration.new(binary_name: "ruby_memcheck_c_test")
+      @configuration = Configuration.new
     end
 
     def test_raises_when_suppressions_generated_but_not_configured
@@ -30,7 +30,7 @@ module RubyMemcheck
       XML
 
       error = assert_raises do
-        RubyMemcheck::ValgrindError.new(@configuration, output)
+        RubyMemcheck::ValgrindError.new(@configuration, [], output)
       end
       assert_equal(ValgrindError::SUPPRESSION_NOT_CONFIGURED_ERROR_MSG, error.message)
     end

--- a/test/ruby_memcheck_test.rb
+++ b/test/ruby_memcheck_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RubyMemcheckTest < Minitest::Test
+  def setup
+    RubyMemcheck.instance_variable_set(:@default_configuration, nil)
+  end
+
+  def test_config_sets_default_configuration
+    config = RubyMemcheck.config
+
+    assert_equal(config, RubyMemcheck.default_configuration)
+  end
+
+  def test_default_configuration_creates_new_configuration
+    config = RubyMemcheck.default_configuration
+    refute_nil(config)
+    assert_equal(config, RubyMemcheck.default_configuration)
+  end
+end


### PR DESCRIPTION
$LOADED_FEATURES is now automatically communicated from the spawned process back into the main ruby_memcheck process which allows ruby_memcheck to automatically detect which binaries are native extensions and allow ruby_memcheck to work for multiple native extensions.