### PR TITLE
Remove @_memoized ivar from Minitest::Spec objects

### DIFF
--- a/lib/ruby_memcheck/test_helper.rb
+++ b/lib/ruby_memcheck/test_helper.rb
@@ -5,5 +5,18 @@ at_exit do
     f.write($LOADED_FEATURES.join("\n"))
   end
 
+  # We need to remove the @_memoized instance variable from Minitest::Spec
+  # objects because it holds a hash that contains memoized objects in `let`
+  # blocks, this can contain objects that will be reported as a memory leak.
+  if defined?(Minitest::Spec)
+    require "objspace"
+
+    ObjectSpace.each_object(Minitest::Spec) do |obj|
+      if obj.instance_variable_defined?(:@_memoized)
+        obj.remove_instance_variable(:@_memoized)
+      end
+    end
+  end
+
   GC.start
 end


### PR DESCRIPTION
We need to remove the @_memoized instance variable from Minitest::Spec objects because it holds a hash that contains memoized objects in `let` blocks, this can contain objects that will be reported as a memory leak.