### PR TITLE
Set `RUBY_FREE_AT_EXIT` for Ruby >= 3.3.0

### DIFF
--- a/lib/ruby_memcheck/test_task_reporter.rb
+++ b/lib/ruby_memcheck/test_task_reporter.rb
@@ -21,6 +21,7 @@ module RubyMemcheck
     def setup
       ENV["RUBY_MEMCHECK_LOADED_FEATURES_FILE"] = File.expand_path(configuration.loaded_features_file)
       ENV["RUBY_MEMCHECK_RUNNING"] = "1"
+      ENV["RUBY_FREE_AT_EXIT"] = "1"
     end
 
     def report_valgrind_errors

--- a/test/ruby_memcheck/shared_test_task_reporter_tests.rb
+++ b/test/ruby_memcheck/shared_test_task_reporter_tests.rb
@@ -223,10 +223,22 @@ module RubyMemcheck
       end
     end
 
-    def test_envionment_variable_RUBY_MEMCHECK_RUNNING
+    def test_environment_variable_RUBY_MEMCHECK_RUNNING
       Tempfile.create do |tempfile|
         ok = run_with_memcheck(<<~RUBY, raise_on_failure: false)
           File.write(#{tempfile.path.inspect}, ENV["RUBY_MEMCHECK_RUNNING"])
+        RUBY
+
+        assert(ok)
+        assert_empty(@test_task.reporter.errors)
+        assert_includes(tempfile.read, "1")
+      end
+    end
+
+    def test_environment_variable_RUBY_FREE_AT_EXIT
+      Tempfile.create do |tempfile|
+        ok = run_with_memcheck(<<~RUBY, raise_on_failure: false)
+          File.write(#{tempfile.path.inspect}, ENV["RUBY_FREE_AT_EXIT"])
         RUBY
 
         assert(ok)


### PR DESCRIPTION
For more information, see:

- https://bugs.ruby-lang.org/issues/19993
- https://github.com/ruby/ruby/pull/8868
- https://github.com/ruby/ruby/pull/9302