### PR TITLE
Lower the limit on file descriptors with `ulimit -n`

### DIFF
--- a/lib/ruby_memcheck/configuration.rb
+++ b/lib/ruby_memcheck/configuration.rb
@@ -100,6 +100,15 @@ module RubyMemcheck
         #     ruby_init_stack (thread_pthread.c:871)
         #     main (main.c:48)
         "ulimit -s unlimited && ",
+        # On some distros, and in some Docker containers, the number of file descriptors is set to a
+        # very high number like 1073741816 that valgrind >= 3.21.0 will error out on:
+        #   --184100:0:libcfile Valgrind: FATAL: Private file creation failed.
+        #      The current file descriptor limit is 1073741804.
+        #      If you are running in Docker please consider
+        #      lowering this limit with the shell built-in limit command.
+        #   --184100:0:libcfile Exiting now.
+        # See https://bugs.kde.org/show_bug.cgi?id=465435 for background information.
+        "ulimit -n 8192 && ",
         valgrind,
         valgrind_options,
         valgrind_suppression_files.map { |f| "--suppressions=#{f}" },


### PR DESCRIPTION
Valgrind 3.21.0 will exit if the fd limit is too high. This change is described here:

> https://bugs.kde.org/show_bug.cgi?id=465435

And the symptom is that Valgrind exits prematurely with this error message:

```
--184100:0:libcfile Valgrind: FATAL: Private file creation failed.
   The current file descriptor limit is 1073741804.
   If you are running in Docker please consider
   lowering this limit with the shell built-in limit command.
--184100:0:libcfile Exiting now.
```

A quote from a maintainer in that issue is: "We're not going to change Valgrind to handle insane rlimits that Docker presents", however it looks like Ubuntu 24.10 sets this limit very high:

    $ uname -a
    Linux bepi 6.11.0-1004-lowlatency #4-Ubuntu SMP PREEMPT_DYNAMIC Mon Sep 30 10:54:09 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
    $ ulimit -n
    1073741816

I suspect this patch will not work on some systems for a variety of reasons, but I wanted to start a conversation about how to address this issue.