### PR TITLE
Add rb_vm_exec to DEFAULT_SKIPPED_RUBY_FUNCTIONS

### DIFF
--- a/lib/ruby_memcheck/configuration.rb
+++ b/lib/ruby_memcheck/configuration.rb
@@ -29,6 +29,7 @@ module RubyMemcheck
       /\Arb_rescue/,
       /\Arb_respond_to\z/,
       /\Arb_thread_create\z/, # Threads are relased to a cache, so they may be reported as a leak
+      /\Arb_vm_exec\z/,
       /\Arb_yield/,
     ].freeze
     RUBY_FREE_AT_EXIT_SUPPORTED = Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0")


### PR DESCRIPTION
It seems like rb_eval_string is optimized out in Ruby 3.3.6 and 3.4.1 and Ruby head, so the top frame becauses rb_vm_exec.